### PR TITLE
Moved Travis builds to Trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 sudo: required
+dist: trusty
 
 compiler:
 - gcc


### PR DESCRIPTION
Precise doesn't have Qt5 packages anymore.
